### PR TITLE
fix: typing error in sdk/index.js

### DIFF
--- a/src/sdk/index.js
+++ b/src/sdk/index.js
@@ -1,2 +1,2 @@
 exports.Client = require("./Client").Client;
-exports.Shortcodes = require("./ShortCodes").Shortcodes;
+exports.Shortcodes = require("./Shortcodes").Shortcodes;


### PR DESCRIPTION
Shortcodes.js hasn't "c" in uppercase in filename, this creates a build error on Netlify.

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Error caught during Netlify build : 
```bash
`Error` was thrown:
   Error: Cannot find module './ShortCodes'
   Require stack:
      - /opt/build/repo/node_modules/eleventy-plugin-prismic/src/sdk/index.js
```

## Checklist

- [x] My change doesn't requires a change to the documentation.


---
![happy dog](https://media.giphy.com/media/a3IWyhkEC0p32/giphy.gif)
