### PR TITLE
 support for Prismic Client 6.0.0-beta.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -765,7 +765,7 @@
 			"dev": true
 		},
 		"node_modules/@prismicio/client": {
-			"version": "6.0.0-beta.2",
+			"version": "6.0.0-beta.3",
 			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.0.0-beta.2.tgz",
 			"integrity": "sha512-VBBNwmsm1DisoIp5jKa2f+tIBVNLb1M3a4S/++63XhTsf4prATIGPREHdMFIdj70k9Jq51CqGiIyUUY+2OHZyQ==",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"unit": "nyc --reporter=lcovonly --reporter=text --exclude-after-remap=false ava"
 	},
 	"dependencies": {
-		"@prismicio/client": "^6.0.0-beta",
+		"@prismicio/client": "^6.0.0-beta.3",
 		"@prismicio/helpers": "^2.0.0-beta",
 		"@prismicio/types": "^0.1.15",
 		"dayjs": "^1.10.7",

--- a/src/crawlAndSort.ts
+++ b/src/crawlAndSort.ts
@@ -19,7 +19,7 @@ export const crawlAndSort = async (
 	client: Client,
 	options: PrismicPluginOptions = {},
 ): Promise<Record<string, PrismicDocument | PrismicDocument[]>> => {
-	const docs = await client.getAll();
+	const docs = await client.dangerouslyGetAll();
 
 	const sortedDocs = docs.reduce(
 		(

--- a/test/pluginPrismic.test.ts
+++ b/test/pluginPrismic.test.ts
@@ -57,7 +57,7 @@ test.serial("injects documents from client instance", async (t) => {
 
 	await new Promise((res) => {
 		setTimeout(() => {
-			t.true(spiedClient.getAll.calledOnce);
+			t.true(spiedClient.dangerouslyGetAll.calledOnce);
 			t.true(spiedEleventyConfig.addGlobalData.calledOnce);
 			res(null);
 		}, 200);


### PR DESCRIPTION
refactor!: support for Prismic Client 6.0.0-beta.3

BREAKING CHANGE: refactor to use client.dangerouslyGetAll() instead of client.getAll()

## Types of changes
- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Prismic Client 6.0.0-beta.3 breaks this plugin by renaming client.getAll() to client.dangerouslyGetAll(). 

This change updates the call and test to use client.dangerouslyGetAll() and sets @prismicio/client to use ^6.0.0-beta.3.

This resolves [this issue](https://github.com/prismicio-community/eleventy-plugin-prismic/issues/4): 

## Checklist:

- [ ] My change requires an update to the documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.
